### PR TITLE
HT-6266: Move to new environment-based hosted-zones

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -153,13 +153,13 @@ resource "aws_msk_scram_secret_association" "default" {
 }
 
 module "hostname" {
-  count   = (var.number_of_broker_nodes > 0) && (var.zone_id != null) ? var.number_of_broker_nodes : 0
-  source  = "cloudposse/route53-cluster-hostname/aws"
-  version = "0.12.0"
-  enabled = module.this.enabled && length(var.zone_id) > 0
-  name    = "${module.this.name}-broker-${count.index + 1}"
-  zone_id = var.zone_id
-  records = [split(":", local.bootstrap_brokers_combined_list[count.index])[0]]
+  count    = (var.number_of_broker_nodes > 0) && (var.zone_id != null) ? var.number_of_broker_nodes : 0
+  source   = "cloudposse/route53-cluster-hostname/aws"
+  version  = "0.12.0"
+  enabled  = module.this.enabled && length(var.zone_id) > 0
+  dns_name = "${module.this.name}-broker-${count.index + 1}"
+  zone_id  = var.zone_id
+  records  = [split(":", local.bootstrap_brokers_combined_list[count.index])[0]]
 
   context = module.this.context
 }


### PR DESCRIPTION
## Ticket
[Ticket.](https://humnai.atlassian.net/browse/HT-6266)
## Changes
* Pass in the `dns_name` attribute to the `cloudposse/route53-cluster-hostname/aws` module, so that the DNS name generated no longer has the environment or namespace in its name.
  * E.g., `dev-humnai-msk-broker-1.rideshur.com` becomes `msk-broker-1.rideshur.com`.
## Notes
The zone ID variable must be updated next time the clusters are redeployed, so that they are deployed into their environment-based hosted zones.